### PR TITLE
Fix Open SaaS spelling in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 Thanks so much for considering contributing to Open SaaS 🙏
 
 ## Considerations before Contributing
+
 Check if there is a GitHub issue already for the thing you would like to work on. If there is no issue yet, create a new one.
 
 Let us know, in the issue, that you would like to work on it and how you plan to approach it.
@@ -15,6 +16,7 @@ Repo is divided into two main parts: [template](/template) dir and [opensaas-sh]
 `opensaas-sh` is the app deployed to https://opensaas.sh , and is actually made with open saas! It contains a demo app and open saas docs. We keep it updated as we work on the template.
 
 ## How to Contribute
+
 1. Make sure you understand the basics of how open-saas works (check out [docs](https://docs.opensaas.sh)).
 2. Check out this repo (`main` branch) and make sure you are able to get the app in [template/app/](/template/app) running (to set it up, follow the same steps as for running a new open-saas app, as explained in the open-saas docs).
 3. Create a new git branch for your work (aka feature branch) and do your changes on it.
@@ -33,7 +35,7 @@ Whenever a user starts a new Wasp project with `wasp new -t <template_name>`, Wa
 
 In the case of Open SaaS, which is a Wasp template, the tag is `wasp-v{{version}}-template`, where `{{version}}` is the current version of Wasp, e.g. `wasp-v0.13-template`.
 
-We manually (re)assign the appropriate tag when we are ready to release a new version of Open Saas.
+We manually (re)assign the appropriate tag when we are ready to release a new version of Open SaaS.
 
 ### Releasing
 

--- a/opensaas-sh/README.md
+++ b/opensaas-sh/README.md
@@ -1,8 +1,8 @@
-# OpenSaas.sh
+# OpenSaaS.sh
 
-This is the https://opensaas.sh page and demo app, built with the Open Saas template!
+This is the https://opensaas.sh page and demo app, built with the Open SaaS template!
 
-It consists of a Wasp app for showcasing the Open Saas template (+ landing page), while the Astro blog is blog and docs for the Open Saas template, found at https://docs.opensaas.sh.
+It consists of a Wasp app for showcasing the Open SaaS template (+ landing page), while the Astro blog is blog and docs for the Open SaaS template, found at https://docs.opensaas.sh.
 
 Inception :)!
 
@@ -42,7 +42,7 @@ Make sure not to commit `app/` to git. It is currently (until we resolve this) n
 
 ### Blog (blog/)
 
-Blog (and docs in it) is currently tracked in whole, as it has quite some content, so updating it to the latest version of Open Saas is done manually, but it might be interesting to also move it to the `diff` approach, as we use for the demo app, if it turns out to be a good match.
+Blog (and docs in it) is currently tracked in whole, as it has quite some content, so updating it to the latest version of Open SaaS is done manually, but it might be interesting to also move it to the `diff` approach, as we use for the demo app, if it turns out to be a good match.
 
 For more info on authoring content for the docs and blog, including information on custom components, see the [blog/README.md](blog/README.md).
 

--- a/opensaas-sh/blog/src/content/docs/blog/2024-10-10-most-annoying-cookie-banner-contest.mdx
+++ b/opensaas-sh/blog/src/content/docs/blog/2024-10-10-most-annoying-cookie-banner-contest.mdx
@@ -9,22 +9,23 @@ tags:
 hideBannerImage: true
 authors: vince
 ---
+
 import { Image } from 'astro:assets';
 import wheel from '@assets/cookie-consent/wheel.gif';
 import enter from '@assets/cookie-consent/enter.gif';
 import keyboard from '@assets/cookie-consent/keyboard.jpg';
 import share from '@assets/cookie-consent/image.png';
 
-<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
-  <iframe 
-    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
-    src="https://www.youtube.com/embed/tLEEk8Q5jo4?si=U-nROtawDHrjJ4k0" 
-    title="YouTube video player" 
-    frameborder="0" 
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
-    referrerpolicy="strict-origin-when-cross-origin" 
-    allowfullscreen>
-  </iframe>
+<div style='position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;'>
+  <iframe
+    style='position: absolute; top: 0; left: 0; width: 100%; height: 100%;'
+    src='https://www.youtube.com/embed/tLEEk8Q5jo4?si=U-nROtawDHrjJ4k0'
+    title='YouTube video player'
+    frameborder='0'
+    allow='accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share'
+    referrerpolicy='strict-origin-when-cross-origin'
+    allowfullscreen
+  ></iframe>
 </div>
 
 ## What kind of hackathon is this?
@@ -33,20 +34,19 @@ The goal here is simple. Make **THE MOST ANNOYING COOKIE BANNER** you can think 
 
 Cookie consent banners annoy us all. So we thought, why not have some fun with them? Here are a couple examples of what that might look like:
 
-1. *The Cookie Consent Wheel of Fortune:*
+1. _The Cookie Consent Wheel of Fortune:_
 
 <Image src={wheel} alt='Consent wheel' loading='lazy' />
 
-2. *The “Hit Enter When the Red Ball is Over the Accept Button to Consent” Banner:* 
-    
+2. _The “Hit Enter When the Red Ball is Over the Accept Button to Consent” Banner:_
+
 <Image src={enter} alt='Enter to win' loading='lazy' />
-    
 
 Now it’s time for you to get creative. Btw, if you’re looking for some inspiration, check out these [Ridiculous Volume Slider UI’s](https://uxdesign.cc/the-worst-volume-control-ui-in-the-world-60713dc86950).
 
 ## Prizes
 
-2 winners will receive a nice mechanical keyboard, an additional *annoying* gift, as well as a shoutout on our socials.
+2 winners will receive a nice mechanical keyboard, an additional _annoying_ gift, as well as a shoutout on our socials.
 
 The 2 winners will be selected by:
 
@@ -62,16 +62,13 @@ The community will get a chance to vote in a battle royale style elimination tou
 ## How to participate
 
 - Fork the [Annoying Cookie Banner Stackblitz Template](https://stackblitz.com/edit/vitejs-vite-uiyjag?file=src%2Flanding-page%2Fcomponents%2FCookieConsentBanner.tsx)
-    - If you prefer to work in your own editor, just click on the `Create a repository` button after you fork the template
+  - If you prefer to work in your own editor, just click on the `Create a repository` button after you fork the template
 - When finished with your banner, click on `Share` in the top left, and in the `Embed` tab, click `Copy URL` with the following settings:
-    
   <Image src={share} alt='Share' loading='lazy' />
-    
 - Next, [edit the `MOST-ANNOYING-COOKIE-BANNER.md` file](https://github.com/wasp-lang/open-saas/edit/main/MOST-ANNOYING-COOKIE-BANNER.md) on the Open SaaS repo.
-    - Enter your GitHub username followed by the embed link you copied from Stackblitz 
-    - Note: after you create a PR, the Wasp team will add the `ANNOYING COOKIE BANNER` label to it. 
-    
-- Make sure you also ⭐️ [star the Open Saas repository](https://github.com/wasp-lang/open-saas) to be eligible to win!
+  - Enter your GitHub username followed by the embed link you copied from Stackblitz
+  - Note: after you create a PR, the Wasp team will add the `ANNOYING COOKIE BANNER` label to it.
+- Make sure you also ⭐️ [star the Open SaaS repository](https://github.com/wasp-lang/open-saas) to be eligible to win!
 
 ## Deadline & Results
 
@@ -81,7 +78,7 @@ Be sure to join our [Discord](https://discord.gg/rzdnErX) or follow us on [Twitt
 
 ## Let's annoy our users! 🚀
 
-Let's create the most annoying cookie consent banner and have some fun! This hackathon is your chance to show off your creativity and tech skills. We're super excited to see what wild ideas you come up with. 
+Let's create the most annoying cookie consent banner and have some fun! This hackathon is your chance to show off your creativity and tech skills. We're super excited to see what wild ideas you come up with.
 
 Remember, this is all about having fun and pushing the boundaries of user interface design!
 

--- a/opensaas-sh/blog/src/content/docs/guides/authentication.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authentication.md
@@ -5,13 +5,13 @@ banner:
     Have an Open SaaS app in production? <a href="https://e44cy1h4s0q.typeform.com/to/EPJCwsMi">We'll send you some swag! 👕</a>
 ---
 
-Setting up your app's authentication is easy with Wasp. In fact, it's already set up for you in the `main.wasp` file: 
+Setting up your app's authentication is easy with Wasp. In fact, it's already set up for you in the `main.wasp` file:
 
 ```tsx title="main.wasp"
   auth: {
     userEntity: User,
     methods: {
-      email: {}, 
+      email: {},
       google: {},
       gitHub: {},
       discord: {}
@@ -24,7 +24,7 @@ The great part is, by defining your auth config in the `main.wasp` file, Wasp ma
 
 ## Email Verified Auth
 
-`email` method is the default auth method in Open Saas.
+`email` method is the default auth method in Open SaaS.
 
 Since it needs to send emails to verify users and reset passwords, it requires an [email sender](https://wasp.sh/docs/advanced/email) provider: a service it can use to send emails.
 "email sender" provider is configured via `app.emailSender` field in the `main.wasp` file.
@@ -38,19 +38,20 @@ You can then follow these links to verify the user and continue with the sign-up
     provider: Dummy, // logs all email verification links/tokens to the server's console
     defaultFrom: {
       name: "Open SaaS App",
-      email: "me@example.com" 
+      email: "me@example.com"
     },
   },
 ```
 
-You **can not use the Dummy provider in production** and your app **will not build** until you move to a production-ready provider, such as SendGrid. We outline the process of migrating to SendGrid below. 
+You **can not use the Dummy provider in production** and your app **will not build** until you move to a production-ready provider, such as SendGrid. We outline the process of migrating to SendGrid below.
 :::
 
-In order to use the `email` auth method in production, you'll need to switch from the `Dummy` "email sender" provider to a production-ready provider like SendGrid: 
+In order to use the `email` auth method in production, you'll need to switch from the `Dummy` "email sender" provider to a production-ready provider like SendGrid:
 
-1. First, set up your app's `emailSender` in the `main.wasp` file by following [this guide](/guides/email-sending/#integrate-your-email-sender). 
+1. First, set up your app's `emailSender` in the `main.wasp` file by following [this guide](/guides/email-sending/#integrate-your-email-sender).
 2. Add your `SENDGRID_API_KEY` to the `.env.server` file.
-3. Make sure the email address you use in the `fromField` object is the same email address that you configured your SendGrid account to send out emails with. In the end, your `main.wasp` file should look something like this: 
+3. Make sure the email address you use in the `fromField` object is the same email address that you configured your SendGrid account to send out emails with. In the end, your `main.wasp` file should look something like this:
+
 ```ts title="main.wasp" {6,7} del={15} ins={16}
   auth: {
     methods: {
@@ -58,10 +59,10 @@ In order to use the `email` auth method in production, you'll need to switch fro
         fromField: {
           name: "Open SaaS App",
           // When using SendGrid, you must use the same email address that you configured your account to send out emails with!
-          email: "me@example.com" 
+          email: "me@example.com"
         },
         //...
-      }, 
+      },
     }
   },
   //...
@@ -71,19 +72,18 @@ In order to use the `email` auth method in production, you'll need to switch fro
     defaultFrom: {
       name: "Open SaaS App",
       // When using SendGrid, you must use the same email address that you configured your account to send out emails with!
-      email: "me@example.com" 
+      email: "me@example.com"
     },
   },
-  ```
-
+```
 
 And that's it. Wasp will take care of the rest and update your AuthUI components accordingly.
 
-Check out the  [Wasp Auth docs](https://wasp.sh/docs/auth/overview) for more info.
+Check out the [Wasp Auth docs](https://wasp.sh/docs/auth/overview) for more info.
 
 ## Google, GitHub, & Discord Auth
 
-We've also customized and pre-built the Google and GitHub auth flow for you. To start using them, you just need to uncomment out the methods you want in your `main.wasp` file and obtain the proper API keys to add to your `.env.server` file. 
+We've also customized and pre-built the Google and GitHub auth flow for you. To start using them, you just need to uncomment out the methods you want in your `main.wasp` file and obtain the proper API keys to add to your `.env.server` file.
 
 To create a Google OAuth app and get your Google API keys, follow the instructions in [Wasp's Google Auth docs](https://wasp.sh/docs/auth/social-auth/google#3-creating-a-google-oauth-app).
 

--- a/opensaas-sh/blog/src/content/docs/guides/authorization.md
+++ b/opensaas-sh/blog/src/content/docs/guides/authorization.md
@@ -5,7 +5,7 @@ banner:
     Have an Open SaaS app in production? <a href="https://e44cy1h4s0q.typeform.com/to/EPJCwsMi">We'll send you some swag! 👕</a>
 ---
 
-This guide will help you get started with authorization in your SaaS app. 
+This guide will help you get started with authorization in your SaaS app.
 
 Authorization refers to what users can access in your app. This is useful for differentiating between users who have paid for different subscription tiers (e.g. "hobby" vs "pro"), or between users who have admin privileges and those who do not.
 
@@ -17,7 +17,7 @@ Also, check out our [blog post](https://wasp.sh/blog/2022/11/29/permissions-in-w
 
 ### Client-side Authorization
 
-Open Saas starts with all users having access to the landing page (`/`), but only authenticated users having access to the rest of the app (e.g. to the `/demo-app`, or to the `/account`).
+Open SaaS starts with all users having access to the landing page (`/`), but only authenticated users having access to the rest of the app (e.g. to the `/demo-app`, or to the `/account`).
 
 To control which pages require users to be authenticated to access them, you can set the `authRequired` property of the corresponding `page` definition in your `main.wasp` file:
 
@@ -38,37 +38,34 @@ Actually ensuring they don't have access to the data, that is on the server to e
 :::
 
 If you want more fine-grained control over what users can access, there are two Wasp-specific options:
+
 1. When you define the `authRequired: true` property on the `page` definition, Wasp automatically passes the User object to the page component. Here you can check for certain user properties before authorizing access:
 
 ```tsx title="ExamplePage.tsx" "{ user }: { user: User }"
-import { type User } from "wasp/entities";
+import { type User } from 'wasp/entities';
 
 export default function Example({ user }: { user: User }) {
-
   if (user.subscriptionStatus === 'past_due') {
-    return (<span>Your subscription is past due. Please update your payment information.</span>)
+    return <span>Your subscription is past due. Please update your payment information.</span>;
   }
   if (user.subscriptionStatus === 'cancel_at_period_end') {
-    return (<span>Your susbscription will end on 01.01.2024</span>)
+    return <span>Your susbscription will end on 01.01.2024</span>;
   }
   if (user.subscriptionStatus === 'active') {
-    return (<span>Thanks so much for your support!</span>)
+    return <span>Thanks so much for your support!</span>;
   }
-
 }
 ```
 
 2. Or you can take advantage of the `useAuth` hook and check for certain user properties before authorizing access to certain pages or components:
 
 ```tsx title="ExamplePage.tsx" {1, 4}
-import { useAuth } from "wasp/client/auth";
+import { useAuth } from 'wasp/client/auth';
 
 export default function ExampleHomePage() {
   const { data: user } = useAuth();
 
-  return (
-    <h1> Hi {user.email || 'there'} 👋 </h1>
-  )
+  return <h1> Hi {user.email || 'there'} 👋 </h1>;
 }
 ```
 
@@ -78,7 +75,7 @@ Authorization on the server-side is the core of your access control logic, and d
 
 You can authorize access to server-side operations by adding a check for a logged-in user on the `context.user` object which is passed to all operations in Wasp:
 
-```tsx title="src/server/actions.ts" 
+```tsx title="src/server/actions.ts"
 export const someServerAction: SomeServerAction<...> = async (args, context) => {
   if (!context.user) {
     throw new HttpError(401); // throw an error if user is not logged in
@@ -90,5 +87,3 @@ export const someServerAction: SomeServerAction<...> = async (args, context) => 
   //...
 }
 ```
-
-

--- a/testprojekt/README.md
+++ b/testprojekt/README.md
@@ -1,6 +1,7 @@
 # <YOUR_APP_NAME>
 
-This project is based on [OpenSaas](https://opensaas.sh) template and consists of three main dirs:
+This project is based on [Open SaaS](https://opensaas.sh) template and consists of three main dirs:
+
 1. `app` - Your web app, built with [Wasp](https://wasp.sh).
 2. `e2e-tests` - [Playwright](https://playwright.dev/) tests for your Wasp web app.
 3. `blog` - Your blog / docs, built with [Astro](https://docs.astro.build) based on [Starlight](https://starlight.astro.build/) template.

--- a/testprojekt/app/README.md
+++ b/testprojekt/app/README.md
@@ -1,12 +1,12 @@
 # <YOUR_APP_NAME>
 
-Built with [Wasp](https://wasp.sh), based on the [Open Saas](https://opensaas.sh) template.
+Built with [Wasp](https://wasp.sh), based on the [Open SaaS](https://opensaas.sh) template.
 
 ## Development
 
 ### Running locally
- - Make sure you have the `.env.client` and `.env.server` files with correct dev values in the root of the project.
- - Run the database with `wasp start db` and leave it running.
- - Run `wasp start` and leave it running.
- - [OPTIONAL]: If this is the first time starting the app, or you've just made changes to your entities/prisma schema, also run `wasp db migrate-dev`.
 
+- Make sure you have the `.env.client` and `.env.server` files with correct dev values in the root of the project.
+- Run the database with `wasp start db` and leave it running.
+- Run `wasp start` and leave it running.
+- [OPTIONAL]: If this is the first time starting the app, or you've just made changes to your entities/prisma schema, also run `wasp db migrate-dev`.


### PR DESCRIPTION
## Summary
- replace various mentions of `OpenSaas` and `Open Saas` with **Open SaaS** in documentation
- run Prettier on the updated docs

## Testing
- `npx --yes prettier -c testprojekt/README.md testprojekt/app/README.md opensaas-sh/README.md CONTRIBUTING.md opensaas-sh/blog/src/content/docs/blog/2024-10-10-most-annoying-cookie-banner-contest.mdx opensaas-sh/blog/src/content/docs/guides/authorization.md opensaas-sh/blog/src/content/docs/guides/authentication.md`